### PR TITLE
preparing for subtree conversion

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,2 @@
+from metaconfigure import description
+from metaconfigure import cmake

--- a/cmake.py
+++ b/cmake.py
@@ -3,8 +3,7 @@ generate cmake files for a project from a serialized project description
 """
 import os
 import textwrap
-import description
-from compiler_configuration import *
+from .compiler_configuration import *
 
 language_string = { 'c' : 'C', 'c++' : 'CXX', 'fortran' : 'Fortran' }
 compiler_string = { 'gcc' : 'GNU',
@@ -24,7 +23,7 @@ def fetch_subprojects( state ):
           set( ROOT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} )
           if ( NOT fetched_subprojects )
               set( fetched_subprojects TRUE CACHE BOOL "fetch script ran")
-              execute_process( COMMAND python "./fetch_subprojects.py"
+              execute_process( COMMAND python "./metaconfigure/fetch_subprojects.py"
                                WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} )
           endif()
       endif()

--- a/description.py
+++ b/description.py
@@ -4,12 +4,12 @@ A script to generate a serialized project description for build script generatio
 import os
 import glob
 import json
-from compiler_configuration import *
+from .compiler_configuration import *
 
 root = None
 
 def serialize( state ):
-    with open (".metaconfigure/description.json", "w") as json_file:
+    with open ("metaconfigure/description.json", "w") as json_file:
         subprojects = state.pop('subprojects')
         project_path = state.pop('project_path')
         implementation_extensions = state.pop('implementation_extensions')
@@ -21,7 +21,7 @@ def serialize( state ):
         state['header_extensions'] = header_extensions
 
 def deserialize():
-    with open (".metaconfigure/description.json", "r") as json_file:
+    with open ("metaconfigure/description.json", "r") as json_file:
         state = json.loads( json_file.read() )
         state['subprojects'] = {}
         state['project_path'] = os.getcwd()
@@ -168,7 +168,7 @@ def generate( name, target, language, version, is_external_project = False,
     if 'include_path' in state:
         assert os.path.isdir( state['include_path'] )
   
-    if not os.path.exists('.metaconfigure'):
-        os.makedirs('.metaconfigure')
+    if not os.path.exists('metaconfigure'):
+        os.makedirs('metaconfigure')
       
     serialize( state )

--- a/fetch_subprojects.py
+++ b/fetch_subprojects.py
@@ -1,0 +1,75 @@
+#! /usr/bin/env python
+"""
+A script to generate a flat subproject directory from a tree of dependency directories
+"""
+import os
+import subprocess
+import textwrap
+
+def dependency_directory():
+    """
+    A function isolating the path specification to the project's dependency directory
+    """
+    return os.path.join( os.getcwd(), "dependencies" )
+
+def clone_submodule( relative_path ):
+    """
+    A function to clone a git submodule
+    """
+    print( textwrap.dedent(
+      """
+      ----------------------------------------
+      Fetching {relative_path}...
+      ----------------------------------------
+      """.format( relative_path = relative_path ) ) )
+    invocation = [ "git", "submodule", "update", "-q","--init", "--", relative_path ]
+    if os.name == "nt":
+        invocation.insert( 0, "powershell" )
+
+    clone = subprocess.Popen( invocation )
+    clone.communicate()
+
+def update_repository():
+    """
+    A function to update a submodule to lastest commit of the master branch
+    """
+    print("Updating to master branch...")
+    print("")
+    invocation = ["git", "pull", "-q", "origin", "master"]
+    if os.name == "nt":
+        invocation.insert( 0, "powershell" )
+    update = subprocess.Popen( invocation )
+    update.communicate()
+  
+def traverse_dependencies( destination, traversed ):
+    """
+    Clone and update dependencies uniquely and collect links to dependency projects
+    in a destination folder
+    """
+    if not os.path.isdir( dependency_directory() ):
+        return
+    
+    os.chdir( dependency_directory() )
+
+    for dependency in os.listdir(os.getcwd()) :
+        if os.path.isdir( dependency ) and not dependency in traversed :
+            traversed.add( dependency )
+            clone_submodule( dependency )
+            os.chdir( dependency )
+            update_repository()
+            if not os.path.isdir( os.path.join( destination, dependency ) ):
+                os.symlink( os.getcwd(), os.path.join( destination, dependency ) )
+                
+            traverse_dependencies( destination, traversed )
+            os.chdir( ".." )
+            
+    os.chdir( os.path.join( ".." ) )
+
+def collect_subprojects():
+    destination = os.path.join( os.getcwd(), "subprojects" )
+    if not os.path.isdir( destination ):
+        os.makedirs( destination )
+        
+    traverse_dependencies( destination, set() )
+
+collect_subprojects()

--- a/fetch_subprojects.py
+++ b/fetch_subprojects.py
@@ -33,8 +33,7 @@ def update_repository():
     """
     A function to update a submodule to lastest commit of the master branch
     """
-    print("Updating to master branch...")
-    print("")
+    print("Updating to master branch...\n")
     invocation = ["git", "pull", "-q", "origin", "master"]
     if os.name == "nt":
         invocation.insert( 0, "powershell" )


### PR DESCRIPTION
updates style of fetch script and creates a python package for metaconfiguration tasks. To be used as a subtree in other projects.

advantages
- fetch_subprojects script now lives in a single place.
- user calls to fetch_subprojects are now unecessary (handled by cmake script)
- cmake scripts can be regenerated without leaving the source tree

disadvantages
- metaconfigure directory cannot be hidden directory in parent projects.
