### PR TITLE
Bugfix/non cygwin windows

### DIFF
--- a/collect_subprojects.py
+++ b/collect_subprojects.py
@@ -33,6 +33,23 @@ def traverse_dependencies( destination, traversed ):
             traversed.add( dependency )
             os.chdir( dependency )
             if not os.path.isdir( os.path.join( destination, dependency ) ):
+                gitfile = open( ".git", 'r' )
+                gitline = gitfile.readline()
+                gitfile.close()
+
+                gitdir = gitline.split(' ')[1].split('\n')[0]
+
+                if not os.path.isabs( gitdir ):
+                    gitdir = os.path.abspath( gitdir )
+    
+                    gitline = gitline.split(' ')[0] + ' ' + gitdir + '\n'
+
+                    os.remove( ".git" )
+    
+                    gitfile = open( ".git", 'w' )
+                    gitfile.write( gitline )
+                    gitfile.close()
+
                 try:
                     os.symlink( os.getcwd(),
                                 os.path.join( destination, dependency ) )
@@ -45,25 +62,6 @@ def traverse_dependencies( destination, traversed ):
                     shutil.copytree( os.getcwd(),
                                      os.path.join( destination, dependency ),
                                      ignore = shutil.ignore_patterns("dependencies") )
-
-                    gitfilename = os.path.join( destination, dependency, ".git" )
-
-                    gitfile = open( gitfilename, 'r' )
-                    gitline = gitfile.readline()
-                    gitfile.close()
-
-                    gitdir = gitline.split(' ')[1].split('\n')[0]
-
-                    if os.path.isabs( gitdir ):
-                        return
-
-                    gitdir = os.path.abspath( gitdir )
-
-                    gitline = gitline.split(' ')[0] + ' ' + gitdir + '\n'
-
-                    gitfile = open( gitfilename, 'w' )
-                    gitfile.write( gitline )
-                    gitfile.close()
 
             traverse_dependencies( destination, traversed )
             os.chdir( ".." )

--- a/collect_subprojects.py
+++ b/collect_subprojects.py
@@ -46,6 +46,25 @@ def traverse_dependencies( destination, traversed ):
                                      os.path.join( destination, dependency ),
                                      ignore = shutil.ignore_patterns("dependencies") )
 
+                    gitfilename = os.path.join( destination, dependency, ".git" )
+
+                    gitfile = open( gitfilename, 'r' )
+                    gitline = gitfile.readline()
+                    gitfile.close()
+
+                    gitdir = gitline.split(' ')[1].split('\n')[0]
+
+                    if os.path.isabs( gitdir ):
+                        return
+
+                    gitdir = os.path.abspath( gitdir )
+
+                    gitline = gitline.split(' ')[0] + ' ' + gitdir + '\n'
+
+                    gitfile = open( gitfilename, 'w' )
+                    gitfile.write( gitline )
+                    gitfile.close()
+
             traverse_dependencies( destination, traversed )
             os.chdir( ".." )
             

--- a/fetch_subprojects.py
+++ b/fetch_subprojects.py
@@ -68,6 +68,23 @@ def traverse_dependencies( destination, traversed, git ):
             os.chdir( dependency )
             update_repository( git )
             if not os.path.isdir( os.path.join( destination, dependency ) ):
+                gitfile = open( ".git", 'r' )
+                gitline = gitfile.readline()
+                gitfile.close()
+
+                gitdir = gitline.split(' ')[1].split('\n')[0]
+
+                if not os.path.isabs( gitdir ):
+                    gitdir = os.path.abspath( gitdir )
+
+                    gitline = gitline.split(' ')[0] + ' ' + gitdir + '\n'
+
+                    os.remove( ".git" )
+
+                    gitfile = open( ".git", 'w' )
+                    gitfile.write( gitline )
+                    gitfile.close()
+
                 try:
                     os.symlink( os.getcwd(),
                                 os.path.join( destination, dependency ) )


### PR DESCRIPTION
These changes address an issue when building on Windows, but not with Cygwin.  In this case, git seems to populate the .git file with a relative path rather than an absolute path, which it uses when under unix-like systems.  This causes problems when this directory is copied or symlink'd (in the subsequent lines) as it starts with too many changes to parent directories.

To address this problem, the code opens the .git file and reads in the path stored there.  If it's an absolute path already, nothing else is done and the code progresses as it was.  If the path is a relative path, python changes it to an absolute path and replaces the .git file with a new version that uses the absolute path.